### PR TITLE
Robust JSON parsing and retry handling in Gemini interface

### DIFF
--- a/common/gemini_interface.py
+++ b/common/gemini_interface.py
@@ -95,8 +95,13 @@ def ask_gemini_json(prompt: str, task_hint: str = "", config: dict = None, max_r
             print(f"\n-------------------------------------------------------------------")
             print(f"Respuesta JSON de Gemini: {response_text}")
             print(f"\n-------------------------------------------------------------------\n\n")
-            
-            return json.loads(response_text)
+
+            parsed_response = parse_gemini_json_response(response_text)
+            if parsed_response is not None:
+                return parsed_response
+            else:
+                print("Error al parsear la respuesta JSON de Gemini.")
+                raise ValueError("Error al parsear la respuesta JSON de Gemini.")
             
         except Exception as e:
             print(f"Error al llamar a la API de Gemini (intento {attempt + 1}/{max_retries + 1}): {e}")


### PR DESCRIPTION
## Summary
- Replace direct JSON loading with `parse_gemini_json_response` in `ask_gemini_json`
- Retry Gemini JSON requests when parsing fails and log parsing errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0142b731883309e0c8cf2fa0d95d7