### PR TITLE
fix: avoid creating checkpoint dir when clearing

### DIFF
--- a/checkpoints_utils.py
+++ b/checkpoints_utils.py
@@ -70,20 +70,38 @@ def clear_checkpoint(module_name: str, problem_description: str):
     else:
         print(f"INFO: No se encontró checkpoint para eliminar: {filepath}")
 
-def clear_all_checkpoints():
-    """Elimina TODOS los archivos de checkpoint en el directorio de checkpoints."""
-    _ensure_checkpoint_dir() # Asegura que el directorio exista para no fallar si está vacío
-    if os.path.exists(CHECKPOINT_DIR):
-        count = 0
-        for filename in os.listdir(CHECKPOINT_DIR):
-            if filename.endswith(".pkl"): # O cualquier extensión que uses
-                filepath = os.path.join(CHECKPOINT_DIR, filename)
-                try:
-                    os.remove(filepath)
-                    count +=1
-                except Exception as e:
-                    print(f"ERROR: No se pudo eliminar el archivo de checkpoint {filepath}: {e}")
-        if count > 0 :
-            print(f"INFO: Se eliminaron {count} archivos de checkpoint de '{CHECKPOINT_DIR}'.")
-        else:
-            print(f"INFO: No se encontraron checkpoints para eliminar en '{CHECKPOINT_DIR}'.")
+def clear_all_checkpoints() -> int:
+    """Elimina TODOS los archivos de checkpoint en el directorio de checkpoints.
+
+    Returns:
+        int: número de archivos de checkpoint eliminados.
+
+    Nota: La versión original de esta función llamaba siempre a
+    ``_ensure_checkpoint_dir``. Esto creaba el directorio de checkpoints incluso
+    cuando no existía y no había nada que eliminar, lo cual era confuso y
+    dificultaba verificar si realmente existían checkpoints. Ahora simplemente
+    se omite esta creación automática y se retorna el número de archivos
+    eliminados.
+    """
+
+    if not os.path.exists(CHECKPOINT_DIR):
+        # Si no hay directorio, claramente no hay checkpoints que borrar.
+        print(f"INFO: No se encontraron checkpoints para eliminar en '{CHECKPOINT_DIR}'.")
+        return 0
+
+    count = 0
+    for filename in os.listdir(CHECKPOINT_DIR):
+        if filename.endswith(".pkl"):  # O cualquier extensión que uses
+            filepath = os.path.join(CHECKPOINT_DIR, filename)
+            try:
+                os.remove(filepath)
+                count += 1
+            except Exception as e:
+                print(f"ERROR: No se pudo eliminar el archivo de checkpoint {filepath}: {e}")
+
+    if count > 0:
+        print(f"INFO: Se eliminaron {count} archivos de checkpoint de '{CHECKPOINT_DIR}'.")
+    else:
+        print(f"INFO: No se encontraron checkpoints para eliminar en '{CHECKPOINT_DIR}'.")
+
+    return count

--- a/test_clear_checkpoints_utils.py
+++ b/test_clear_checkpoints_utils.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+import checkpoints_utils
+
+def test_clear_all_checkpoints_without_directory(tmp_path, monkeypatch):
+    # point CHECKPOINT_DIR to a non-existent directory inside tmp_path
+    checkpoint_dir = tmp_path / "checkpoints"
+    monkeypatch.setattr(checkpoints_utils, "CHECKPOINT_DIR", str(checkpoint_dir))
+
+    assert not checkpoint_dir.exists()
+    deleted = checkpoints_utils.clear_all_checkpoints()
+    assert deleted == 0
+    assert not checkpoint_dir.exists(), "Function should not create directory when nothing to delete"
+
+
+def test_clear_all_checkpoints_removes_files(tmp_path, monkeypatch):
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+    monkeypatch.setattr(checkpoints_utils, "CHECKPOINT_DIR", str(checkpoint_dir))
+
+    # create dummy checkpoint file
+    dummy = checkpoint_dir / "sample.pkl"
+    dummy.write_text("data")
+
+    deleted = checkpoints_utils.clear_all_checkpoints()
+    assert deleted == 1
+    assert not dummy.exists()
+    assert checkpoint_dir.exists()


### PR DESCRIPTION
## Summary
- avoid creating checkpoint directory when clearing and return number of removed files
- add regression tests for `clear_all_checkpoints`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a009fa2e1c8330bd2626a6a2ae8d1f